### PR TITLE
Use builtin env. variables and replace sed with tail. 

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -2,8 +2,8 @@
 
 AMPATH="/opt/am"
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main"
-arch=$(uname -m)
-currentuser=$(who | awk '{print $1}')
+arch=$(printf '%s\n' "$HOSTTYPE")
+currentuser=$(printf '%s\n' "$USER")
 
 for name in "ar" "cat" "chmod" "chown" "curl" "echo" "egrep" "grep" "sed" "tar" "test" "unzip" "wget" "xterm" "zsync"
 do
@@ -133,7 +133,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/about-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/about-args && echo STOP >> $AMPATH/.cache/about-args
-	ARGS=$(sed '1d' $AMPATH/.cache/about-args)
+	ARGS=$(tail +2 $AMPATH/.cache/about-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -168,7 +168,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/backup-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/backup-args && echo STOP >> $AMPATH/.cache/backup-args
-	ARGS=$(sed '1d' $AMPATH/.cache/backup-args)
+	ARGS=$(tail +2 $AMPATH/.cache/backup-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -202,7 +202,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/download-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/download-args && echo STOP >> $AMPATH/.cache/download-args
-	ARGS=$(sed '1d' $AMPATH/.cache/download-args)
+	ARGS=$(tail +2 $AMPATH/.cache/download-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -242,7 +242,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/home-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/home-args && echo STOP >> $AMPATH/.cache/home-args
-	ARGS=$(sed '1d' $AMPATH/.cache/home-args)
+	ARGS=$(tail +2 $AMPATH/.cache/home-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -285,7 +285,7 @@ case "$1" in
 	rm -R -f $AMPATH/.cache/installed
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/install-args 
 	echo STOP >> $AMPATH/.cache/install-args
-	ARGS=$(sed '1d' $AMPATH/.cache/install-args)
+	ARGS=$(tail +2 $AMPATH/.cache/install-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -361,7 +361,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/overwrite-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/overwrite-args && echo STOP >> $AMPATH/.cache/overwrite-args
-	ARGS=$(sed '1d' $AMPATH/.cache/overwrite-args)
+	ARGS=$(tail +2 $AMPATH/.cache/overwrite-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -413,7 +413,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/remove-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/remove-args && echo STOP >> $AMPATH/.cache/remove-args
-	ARGS=$(sed '1d' $AMPATH/.cache/remove-args)
+	ARGS=$(tail +2 $AMPATH/.cache/remove-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -443,7 +443,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/remove-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/remove-args && echo STOP >> $AMPATH/.cache/remove-args
-	ARGS=$(sed '1d' $AMPATH/.cache/remove-args)
+	ARGS=$(tail +2 $AMPATH/.cache/remove-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then
@@ -477,7 +477,7 @@ case "$1" in
 	do
 	rm -f $AMPATH/.cache/template-args
 	echo $@ | tr ' ' '\n' >> $AMPATH/.cache/template-args && echo STOP >> $AMPATH/.cache/template-args
-	ARGS=$(sed '1d' $AMPATH/.cache/template-args)
+	ARGS=$(tail +2 $AMPATH/.cache/template-args)
 	for arg in $ARGS; do
 	for var in $arg; do
 	if [ $arg == STOP ]; then


### PR DESCRIPTION
First batch of general optimizations.

1. Replaced ```uname -n``` with ```printf '%s\n' "$HOSTTYPE"```. 
- ```"$HOSTTYPE"``` is a builtin environment variable in bash.


2. Replaced ```who | awk '{print $1}'``` with ```$(printf '%s\n "$USER"```.
- ```"$USER"``` is a builtin environment variable in POSIX sh. 


3. Replaced all instances of ```sed '1d'``` with ```tail +2```.
- ```tail``` is faster than ```sed``` in this context.
