### PR TITLE
Fix: Etcher repo name

### DIFF
--- a/programs/x86_64/etcher
+++ b/programs/x86_64/etcher
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 APP=etcher
-REPO="resin-io/etcher"
+REPO="balena-io/etcher"
 
 # CREATE THE FOLDER
 mkdir /opt/$APP
@@ -31,7 +31,7 @@ ln -s /opt/$APP/$APP /usr/local/bin/$APP
 cat >> /opt/$APP/AM-updater << 'EOF'
 #!/usr/bin/env bash
 APP=etcher
-REPO="resin-io/etcher"
+REPO="balena-io/etcher"
 version0=$(cat /opt/$APP/version)
 version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
 if [ $version = $version0 ]; then


### PR DESCRIPTION
Fix repo name due to resin-io no longer being used, and moved to [balena-io](https://github.com/pinarruiz/AM-Application-Manager.git).