### PR TITLE
Changed dependency commands to POSIX compliance.

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -5,11 +5,10 @@ AMREPO="https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main"
 arch=$(printf '%s\n' "$HOSTTYPE")
 currentuser=$(printf '%s\n' "$USER")
 
-for name in "ar" "cat" "chmod" "chown" "curl" "echo" "egrep" "grep" "sed" "tar" "test" "unzip" "wget" "zsync"
-do
-  [[ $(which $name 2>/dev/null) ]] || { echo "" && echo -e 'ERROR: "'$name'" not found, required by some installation scripts.';deps=1; }
-done
-[[ $deps -ne 1 ]] || { echo -e "\nInstall the above and try again\n";exit 1; }
+for name in "ar" "cat" "chmod" "chown" "curl" "grep" "sed" "tar" "unzip" "wget" "zsync"; do
+  test -x "$(command -v $name 2>/dev/null)" \
+  || { printf "\n%s\n" "ERROR: $name not found, required by some installation scripts."; deps=1; };
+done; [ "$deps" -ne 1 ] || { printf "\nInstall the above and try again\n\n"; exit 1; }
 
 rm -R -f $AMPATH/options
 echo -e "about\nbackup\nclean\ndownload\nfiles\ninstall\nlist\nlock\noverwrite\nquery\nremove\nsync\ntemplate\nunlock\nupdate\nweb\n--disable-completion\n--enable-completion\n--home" >> $AMPATH/options

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -8,7 +8,7 @@ currentuser=$(printf '%s\n' "$USER")
 for name in "ar" "cat" "chmod" "chown" "curl" "grep" "sed" "tar" "unzip" "wget" "zsync"; do
   test -x "$(command -v $name 2>/dev/null)" \
   || { printf "\n%s\n" "ERROR: $name not found, required by some installation scripts."; deps=1; };
-done; [ "$deps" -ne 1 ] || { printf "\nInstall the above and try again\n\n"; exit 1; }
+done; [ "$deps" != "1" ] || { printf "\nInstall the above and try again\n\n"; exit 1; }
 
 rm -R -f $AMPATH/options
 echo -e "about\nbackup\nclean\ndownload\nfiles\ninstall\nlist\nlock\noverwrite\nquery\nremove\nsync\ntemplate\nunlock\nupdate\nweb\n--disable-completion\n--enable-completion\n--home" >> $AMPATH/options


### PR DESCRIPTION
I would like to be able to run AM on distros like Alpine or KISS which do not have bash. I will slowly start porting it over to POSIX sh. 

Here are the details of the changes:

= echo and test are builtin commands for all shells. It's not necessary to check for them. 
== You can test it with this command: $ type echo test

= egrep was deprecated for "grep -E". I don't see egrep actually being used in this file. Is it used anywhere in the repo?
== https://www.gnu.org/software/grep/manual/grep.html

= Changed the bash "[[" command to the POSIX "[" command.

= Replaced "which" with the POSIX alternative, "command -v".

= Replaced echo with printf: https://unix.stackexchange.com/a/65819
