### PR TITLE
Fix icon for another-redis-desktop-manager

### DIFF
--- a/programs/x86_64/another-redis-desktop-manager
+++ b/programs/x86_64/another-redis-desktop-manager
@@ -64,11 +64,11 @@ cd /opt/$APP
 mv squashfs-root/*.desktop ./$APP.desktop
 mv squashfs-root/share/applications/*.desktop ./$APP.desktop
 mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
+if [ ! -e ./$APP.desktop ]; then
+	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop
 	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
 fi
-if [ ! -e ./$APP.desktop ]; then 
+if [ ! -e ./$APP.desktop ]; then
 	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
 	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
 fi
@@ -96,6 +96,7 @@ mv ./squashfs-root/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/n
 mv ./squashfs-root/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
 mv ./squashfs-root/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
 mv ./squashfs-root/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
+mv ./squashfs-root/usr/share/icons/hicolor/0x0/apps/*$app* ./icons/$APP 2>/dev/null
 mv ./squashfs-root/usr/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
 mv ./squashfs-root/usr/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
 mv ./squashfs-root/usr/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null


### PR DESCRIPTION
There is no icon after installation, I found it here:

```
$ another-redis-desktop-manager --appimage-extract "usr/share/icons/*/*/*/*"
squashfs-root/usr/share/icons/hicolor/0x0/apps/another-redis-desktop-manager.png
```