### PR TITLE
Update quarto-cli that the script fetches the latest instead of pre-r…

### DIFF
--- a/programs/x86_64/quarto-cli
+++ b/programs/x86_64/quarto-cli
@@ -32,7 +32,7 @@ cat >> /opt/$APP/AM-updater << 'EOF'
 APP=quarto-cli
 REPO="quarto-dev/quarto-cli"
 version0=$(cat /opt/$APP/version)
-version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "amd64.tar.gz" | cut -d '"' -f 4 | head -1)
+version=$(wget -q https://api.github.com/repos/$REPO/releases/latest -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "amd64.tar.gz" | cut -d '"' -f 4 | head -1)
 if [ $version = $version0 ]; then
   echo "Update not needed!"
 else

--- a/programs/x86_64/quarto-cli
+++ b/programs/x86_64/quarto-cli
@@ -16,7 +16,7 @@ chmod a+x /opt/$APP/remove
 mkdir tmp
 cd ./tmp
 
-version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "amd64.tar.gz" | cut -d '"' -f 4 | head -1)
+version=$(wget -q https://api.github.com/repos/$REPO/releases/latest -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "amd64.tar.gz" | cut -d '"' -f 4 | head -1)
 wget $version
 echo "$version" >> /opt/$APP/version
 cd ..


### PR DESCRIPTION
…elease

My test in my terminal:
```

➤ wget https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "amd64.tar.gz" | cut -d '"' -f 4 | head -1
--2023-10-15 13:34:47--  https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest
Resolving api.github.com (api.github.com)... 140.82.121.5
Connecting to api.github.com (api.github.com)|140.82.121.5|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/json]
Saving to: ‘STDOUT’

-                                              [ <=>                                                                                    ]  23.90K  --.-KB/s    in 0.02s   

2023-10-15 13:34:48 (1.23 MB/s) - written to stdout [24476]

https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.450/quarto-1.3.450-linux-amd64.tar.gz

```

See https://github.com/ivan-hc/AM-Application-Manager/issues/79