### PR TITLE
Update blender so that the latest stable version will be installed

### DIFF
--- a/programs/x86_64/blender
+++ b/programs/x86_64/blender
@@ -18,7 +18,7 @@ mkdir tmp
 cd ./tmp
 
 url=https://builder.blender.org/download/daily/archive/
-version=$(wget -q $url -O - | grep -Eo "$url[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep $branch | tail -1)
+version=$(wget -q $url -O - | grep -Eo "$url[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep $branch | head -1)
 wget $version
 echo "$version" >> /opt/$APP/version
 tar fx *.tar.xz
@@ -36,7 +36,7 @@ cat >> /opt/$APP/AM-updater << 'EOF'
 branch=DEVELOPMENTBRANCH
 APP=blender
 url=https://builder.blender.org/download/daily/archive/
-version=$(wget -q $url -O - | grep -Eo "$url[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep $branch | tail -1)
+version=$(wget -q $url -O - | grep -Eo "$url[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep $branch | head -1)
 version0=$(cat /opt/$APP/version)
 if [ $version0 = $version ]; then
   echo "Update not needed, exit!"
@@ -45,7 +45,7 @@ else
   mkdir /opt/$APP/tmp
   cd /opt/$APP/tmp
   url=https://builder.blender.org/download/daily/archive/
-  version=$(wget -q $url -O - | grep -Eo "$url[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep $branch | tail -1)
+  version=$(wget -q $url -O - | grep -Eo "$url[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep $branch | head -1)
   wget $version
   tar fx *.tar.xz
   dir=$(ls . | grep -w -v *.tar.*)


### PR DESCRIPTION
Test in the Terminal

Variant tail
```
➤ wget -q https://builder.blender.org/download/daily/archive/ -O - | grep -Eo "https://builder.blender.org/download/daily/archive/[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep stable | tail -1
https://builder.blender.org/download/daily/archive/blender-3.3.10-stable+v33.11839bc851c7-linux.x86_64-release.tar.xz

```

Variant head
```
➤ wget -q https://builder.blender.org/download/daily/archive/ -O - | grep -Eo "https://builder.blender.org/download/daily/archive/[a-zA-Z0-9./?=_%:-]+[+a-zA-Z0-9./?=_%:-]*" | grep .tar.xz | grep -w -v sha256 | grep stable | head -1
https://builder.blender.org/download/daily/archive/blender-3.6.4-stable+v36.21bfc5e7fe3f-linux.x86_64-release.tar.xz

```

see https://github.com/ivan-hc/AM-Application-Manager/issues/83