### PR TITLE
Update upstream URL for ungoogled-chromium

### DIFF
--- a/programs/x86_64/ungoogled-chromium
+++ b/programs/x86_64/ungoogled-chromium
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 APP=ungoogled-chromium
-REPO="clickot/ungoogled-chromium-binaries"
+REPO="ungoogled-software/ungoogled-chromium-portablelinux"
 
 # CREATE THE FOLDER
 mkdir /opt/$APP
@@ -32,7 +32,7 @@ ln -s /opt/$APP/chrome /usr/local/bin/$APP
 cat >> /opt/$APP/AM-updater << 'EOF'
 #!/usr/bin/env bash
 APP=ungoogled-chromium
-REPO="clickot/ungoogled-chromium-binaries"
+REPO="ungoogled-software/ungoogled-chromium-portablelinux"
 version0=$(cat /opt/$APP/version)
 version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i ".tar.xz" | cut -d '"' -f 4 | head -1)
 if [ $version = $version0 ]; then

--- a/programs/x86_64/ungoogled-chromium-appimage
+++ b/programs/x86_64/ungoogled-chromium-appimage
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 APP=ungoogled-chromium-appimage
-REPO="clickot/ungoogled-chromium-binaries"
+REPO="ungoogled-software/ungoogled-chromium-portablelinux"
 
 # CREATE THE FOLDER
 mkdir /opt/$APP
@@ -31,7 +31,7 @@ ln -s /opt/$APP/$APP /usr/local/bin/$APP
 cat >> /opt/$APP/AM-updater << 'EOF'
 #!/usr/bin/env bash
 APP=ungoogled-chromium-appimage
-REPO="clickot/ungoogled-chromium-binaries"
+REPO="ungoogled-software/ungoogled-chromium-portablelinux"
 version0=$(cat /opt/$APP/version)
 version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
 if [ $version = $version0 ]; then


### PR DESCRIPTION
From https://github.com/clickot/ungoogled-chromium-binaries/releases:

> Note that from now on the binaries themselves are no longer release here but directly in the [ungoogled-chromium-portablelinux](https://github.com/ungoogled-software/ungoogled-chromium-portablelinux/releases) build repo.