### PR TITLE
Rename ungoogled-chromium, fix bash warning

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -880,7 +880,7 @@ case "$1" in
 										break; done
 								esac
 							else
-								echo ' "'$arg'" is NOT a valid argument, please try again!'; echo ""; break
+								echo ' "'$arg'" is NOT a valid argument, please try again!'; echo ""; exit 1
 							fi			
 						fi
 					esac
@@ -2280,7 +2280,7 @@ case "$1" in
 
   'version'|'-v'|'--version')
 
-  	echo "5.3.1-4";;
+  	echo "5.3.1-5";;
 
   *) exec $AMCLIPATH ;;
 

--- a/programs/x86_64/ungoogled-chromium
+++ b/programs/x86_64/ungoogled-chromium
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-APP=ungoogled-chromium-appimage
+APP=ungoogled-chromium
 REPO="ungoogled-software/ungoogled-chromium-portablelinux"
 
 # CREATE THE FOLDER
@@ -30,7 +30,7 @@ ln -s /opt/$APP/$APP /usr/local/bin/$APP
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> /opt/$APP/AM-updater << 'EOF'
 #!/usr/bin/env bash
-APP=ungoogled-chromium-appimage
+APP=ungoogled-chromium
 REPO="ungoogled-software/ungoogled-chromium-portablelinux"
 version0=$(cat /opt/$APP/version)
 version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)


### PR DESCRIPTION
Add a correct name for `ungoogled-chromium`.

And fix a bash warning:

```bash
$ appman install test
-----------------------------------------------------------------------
 >> START OF ALL INSTALLATION PROCESSES <<
-----------------------------------------------------------------------

 "test" is NOT a valid argument, please try again!

appman: line 883: break: only meaningful in a `for', `while', or `until' loop
```